### PR TITLE
Correct check of property 'rules'

### DIFF
--- a/admin/js/css-extract-widget.js
+++ b/admin/js/css-extract-widget.js
@@ -305,7 +305,7 @@
 
             if (el.nodeType === 1) {
                 while (slen && slen--) {
-                    rules = sheets[slen].cssRules || sheets[slen].rules;
+                    rules = sheets[slen].hasOwnProperty('cssRules') || sheets[slen].hasOwnProperty('rules');
                     rlen = rules.length;
 
                     while (rlen && rlen--) {


### PR DESCRIPTION
This Error appears on some pages, if execute 

> window.extractCriticalCSS(  ); 

or 

> window.extractFullCSS(  );

in Browser-Console:

    Failed to read the 'cssRules' property from 'CSSStyleSheet'

Using .hasOwnProperty() on the sheets[slen] Object fix it.